### PR TITLE
Allow setting templates in AdminOptions

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,6 +147,9 @@ use App\Entity\Category;
  *     entity=Category::class,
  *     adminCode="admin_code",
  *     autowireEntity=true,
+ *     templates={
+ *         "list": "admin/category/list.html.twig"
+ *     },
  * )
  */
 class CategoryAdmin

--- a/src/Annotation/AdminOptions.php
+++ b/src/Annotation/AdminOptions.php
@@ -92,6 +92,11 @@ final class AdminOptions
      */
     public $autowireEntity = true;
 
+    /**
+     * @var array<string, string>
+     */
+    public $templates = [];
+
     public function getOptions(): array
     {
         return array_filter(

--- a/src/DependencyInjection/Compiler/AutoConfigureAdminClassesCompilerPass.php
+++ b/src/DependencyInjection/Compiler/AutoConfigureAdminClassesCompilerPass.php
@@ -103,6 +103,10 @@ final class AutoConfigureAdminClassesCompilerPass implements CompilerPassInterfa
                 $definition->addMethodCall('setTranslationDomain', [$annotation->translationDomain]);
             }
 
+            if (!\is_array($annotation->templates)) {
+                continue;
+            }
+
             foreach ($annotation->templates as $name => $template) {
                 $definition->addMethodCall('setTemplate', [$name, $template]);
             }

--- a/src/DependencyInjection/Compiler/AutoConfigureAdminClassesCompilerPass.php
+++ b/src/DependencyInjection/Compiler/AutoConfigureAdminClassesCompilerPass.php
@@ -102,6 +102,10 @@ final class AutoConfigureAdminClassesCompilerPass implements CompilerPassInterfa
             if ($annotation->translationDomain) {
                 $definition->addMethodCall('setTranslationDomain', [$annotation->translationDomain]);
             }
+
+            foreach ($annotation->templates as $name => $template) {
+                $definition->addMethodCall('setTemplate', [$name, $template]);
+            }
         }
     }
 

--- a/tests/DependencyInjection/Compiler/AutoConfigureAdminClassesCompilerPassTest.php
+++ b/tests/DependencyInjection/Compiler/AutoConfigureAdminClassesCompilerPassTest.php
@@ -93,7 +93,11 @@ final class AutoConfigureAdminClassesCompilerPassTest extends TestCase
         );
         
         if ($templates) {
-            $this->assertTrue($adminDefinition->hasMethodCall('setTemplate'));
+            $methodCalls = $adminDefinition->getMethodCalls();
+            $firstMethodCall = \reset($methodCalls);
+            $this->assertSame('setTemplate', $firstMethodCall[0]);
+            $this->assertSame(\key($templates), $firstMethodCall[1][0]);
+            $this->assertSame(\reset($templates), $firstMethodCall[1][1]);
         }
     }
 

--- a/tests/DependencyInjection/Compiler/AutoConfigureAdminClassesCompilerPassTest.php
+++ b/tests/DependencyInjection/Compiler/AutoConfigureAdminClassesCompilerPassTest.php
@@ -43,7 +43,12 @@ final class AutoConfigureAdminClassesCompilerPassTest extends TestCase
     /**
      * @dataProvider processData
      */
-    public function testProcess(string $admin, ?string $entity, ?string $adminCode, array $tagOptions): void
+    public function testProcess(
+        string $admin,
+        ?string $entity,
+        ?string $adminCode,
+        array $tagOptions,
+        array $templates = []): void
     {
         $this->loadConfig([
             'admin' => [
@@ -86,6 +91,10 @@ final class AutoConfigureAdminClassesCompilerPassTest extends TestCase
             $entity,
             $adminDefinition->getArgument(1)
         );
+        
+        if ($templates) {
+            $this->assertTrue($adminDefinition->hasMethodCall('setTemplate'));
+        }
     }
 
     public function processData(): array
@@ -118,6 +127,9 @@ final class AutoConfigureAdminClassesCompilerPassTest extends TestCase
                     'keep_open' => false,
                     'on_top' => false,
                 ],
+                [
+                    "foo" => "foo.html.twig"
+                ]
             ],
             [
                 DisableAutowireEntityAdmin::class,

--- a/tests/Fixtures/Admin/AnnotationAdmin.php
+++ b/tests/Fixtures/Admin/AnnotationAdmin.php
@@ -12,6 +12,9 @@ use KunicMarko\SonataAutoConfigureBundle\Tests\Fixtures\Entity\Category;
  *     label="This is a Label",
  *     entity=Category::class,
  *     group="not test",
+ *     templates={
+ *         "foo": "foo.html.twig"
+ *     },
  * )
  * @author Marko Kunic <kunicmarko20@gmail.com>
  */

--- a/tests/Fixtures/Admin/DisableAutowireEntityAdmin.php
+++ b/tests/Fixtures/Admin/DisableAutowireEntityAdmin.php
@@ -7,7 +7,7 @@ namespace KunicMarko\SonataAutoConfigureBundle\Tests\Fixtures\Admin;
 use KunicMarko\SonataAutoConfigureBundle\Annotation as Sonata;
 
 /**
- * @Sonata\AdminOptions(autowireEntity=false)
+ * @Sonata\AdminOptions(autowireEntity=false, templates=null)
  *
  * @author Marko Kunic <kunicmarko20@gmail.com>
  */


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 1.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
-->

Closes #17.

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Added
- Support for setting templates in `AdminOptions`
```

<!--
     If this is a work in progress, uncomment this section.
     You can add as many tasks as you want.
     If some are not relevant, just remove them.
    
    ## To do
    
    - [ ] Update the tests
    - [ ] Update the documentation
    - [ ] Add an upgrade note
-->
