### PR TITLE
Allow setting child admins in AdminOptions

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,6 +155,7 @@ use Sonata\AdminBundle\Admin\AbstractAdmin;
  *     templates={
  *         "list": "admin/category/list.html.twig"
  *     },
+ *     children={"app.admin.product"}
  * )
  */
 final class CategoryAdmin extends AbstractAdmin

--- a/src/Annotation/AdminOptions.php
+++ b/src/Annotation/AdminOptions.php
@@ -97,6 +97,11 @@ final class AdminOptions
      */
     public $templates = [];
 
+    /**
+     * @var string[]
+     */
+    public $children = [];
+
     public function getOptions(): array
     {
         return \array_filter(

--- a/src/DependencyInjection/Compiler/AutoConfigureAdminClassesCompilerPass.php
+++ b/src/DependencyInjection/Compiler/AutoConfigureAdminClassesCompilerPass.php
@@ -11,6 +11,7 @@ use KunicMarko\SonataAutoConfigureBundle\Exception\EntityNotFound;
 use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Definition;
+use Symfony\Component\DependencyInjection\Reference;
 
 /**
  * @author Marko Kunic <kunicmarko20@gmail.com>
@@ -99,12 +100,16 @@ final class AutoConfigureAdminClassesCompilerPass implements CompilerPassInterfa
                 $definition->addMethodCall('setTranslationDomain', [$annotation->translationDomain]);
             }
 
-            if (!\is_array($annotation->templates)) {
-                continue;
+            if (\is_array($annotation->templates)) {
+                foreach ($annotation->templates as $name => $template) {
+                    $definition->addMethodCall('setTemplate', [$name, $template]);
+                }
             }
 
-            foreach ($annotation->templates as $name => $template) {
-                $definition->addMethodCall('setTemplate', [$name, $template]);
+            if (\is_array($annotation->children)) {
+                foreach ($annotation->children as $childId) {
+                    $definition->addMethodCall('addChild', [new Reference($childId)]);
+                }
             }
         }
     }

--- a/tests/DependencyInjection/Compiler/AutoConfigureAdminClassesCompilerPassTest.php
+++ b/tests/DependencyInjection/Compiler/AutoConfigureAdminClassesCompilerPassTest.php
@@ -132,6 +132,7 @@ final class AutoConfigureAdminClassesCompilerPassTest extends TestCase
                 [
                     'setTemplate',
                     'setTranslationDomain',
+                    'addChild',
                 ],
             ],
             [

--- a/tests/Fixtures/Admin/AnnotationAdmin.php
+++ b/tests/Fixtures/Admin/AnnotationAdmin.php
@@ -16,6 +16,9 @@ use KunicMarko\SonataAutoConfigureBundle\Tests\Fixtures\Entity\Category;
  *     templates={
  *         "foo": "foo.html.twig"
  *     },
+ *     children={
+ *         "admin.product"
+ *     }
  * )
  * @author Marko Kunic <kunicmarko20@gmail.com>
  */


### PR DESCRIPTION
Waiting for tests refactoring (see #18) to write some tests.

## Changelog

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Added
- Support for setting child admins in `AdminOptions`
```
