### PR TITLE
Remove defaults from AdminOptions annotation class

### DIFF
--- a/src/Annotation/AdminOptions.php
+++ b/src/Annotation/AdminOptions.php
@@ -30,22 +30,22 @@ final class AdminOptions
     /**
      * @var bool
      */
-    public $showInDashboard = true;
+    public $showInDashboard;
 
     /**
      * @var bool
      */
-    public $showMosaicButton = true;
+    public $showMosaicButton;
 
     /**
      * @var bool
      */
-    public $keepOpen = false;
+    public $keepOpen;
 
     /**
      * @var bool
      */
-    public $onTop = false;
+    public $onTop;
 
     /**
      * @var string

--- a/tests/DependencyInjection/Compiler/AutoConfigureAdminClassesCompilerPassTest.php
+++ b/tests/DependencyInjection/Compiler/AutoConfigureAdminClassesCompilerPassTest.php
@@ -110,10 +110,6 @@ final class AutoConfigureAdminClassesCompilerPassTest extends TestCase
                     'manager_type' => 'orm',
                     'group' => 'test',
                     'label' => 'Category',
-                    'show_in_dashboard' => true,
-                    'show_mosaic_button' => true,
-                    'keep_open' => false,
-                    'on_top' => false,
                 ],
             ],
             [
@@ -143,10 +139,6 @@ final class AutoConfigureAdminClassesCompilerPassTest extends TestCase
                     'manager_type' => 'orm',
                     'group' => 'test',
                     'label' => 'Disable Autowire Entity',
-                    'show_in_dashboard' => true,
-                    'show_mosaic_button' => true,
-                    'keep_open' => false,
-                    'on_top' => false,
                 ],
             ],
         ];

--- a/tests/Fixtures/Admin/AnnotationAdmin.php
+++ b/tests/Fixtures/Admin/AnnotationAdmin.php
@@ -13,6 +13,10 @@ use KunicMarko\SonataAutoConfigureBundle\Tests\Fixtures\Entity\Category;
  *     entity=Category::class,
  *     group="not test",
  *     translationDomain="Foo",
+ *     showInDashboard=true,
+ *     showMosaicButton=true,
+ *     keepOpen=false,
+ *     onTop=false,
  *     templates={
  *         "foo": "foo.html.twig"
  *     },


### PR DESCRIPTION
Closes #22.

## Changelog

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Removed
- Default annotation values
```
