### PR TITLE
Fix multiple global extensions not working

### DIFF
--- a/src/DependencyInjection/Compiler/AutoConfigureAdminExtensionsCompilerPass.php
+++ b/src/DependencyInjection/Compiler/AutoConfigureAdminExtensionsCompilerPass.php
@@ -50,7 +50,8 @@ final class AutoConfigureAdminExtensionsCompilerPass implements CompilerPassInte
 
             if (!$this->hasTargets($annotation)) {
                 $definition->addTag('sonata.admin.extension', $annotation->getOptions());
-                return;
+
+                continue;
             }
 
             foreach ($annotation->target as $target) {


### PR DESCRIPTION
Multiple global extension doesn't work. The first will win, because a silly error of my PR (`continue `vs `return`).

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Fixed
- Multiple global extensions not working
```
