### PR TITLE
Field names for children.

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,7 +156,9 @@ use Sonata\AdminBundle\Admin\AbstractAdmin;
  *     templates={
  *         "list": "admin/category/list.html.twig"
  *     },
- *     children={"app.admin.product"}
+ *     children={
+ *         "product": "app.admin.product"
+ *     }
  * )
  */
 final class CategoryAdmin extends AbstractAdmin

--- a/src/DependencyInjection/Compiler/AutoConfigureAdminClassesCompilerPass.php
+++ b/src/DependencyInjection/Compiler/AutoConfigureAdminClassesCompilerPass.php
@@ -107,8 +107,12 @@ final class AutoConfigureAdminClassesCompilerPass implements CompilerPassInterfa
             }
 
             if (\is_array($annotation->children)) {
-                foreach ($annotation->children as $childId) {
-                    $definition->addMethodCall('addChild', [new Reference($childId)]);
+                foreach ($annotation->children as $fieldName => $childId) {
+                    if (!\is_numeric($fieldName)) {
+                        $definition->addMethodCall('addChild', [new Reference($childId), $fieldName]);
+                    } else {
+                        $definition->addMethodCall('addChild', [new Reference($childId)]);
+                    }
                 }
             }
         }

--- a/tests/Fixtures/Admin/AnnotationAdmin.php
+++ b/tests/Fixtures/Admin/AnnotationAdmin.php
@@ -21,7 +21,7 @@ use KunicMarko\SonataAutoConfigureBundle\Tests\Fixtures\Entity\Category;
  *         "foo": "foo.html.twig"
  *     },
  *     children={
- *         "admin.product"
+ *         "product": "admin.product"
  *     }
  * )
  * @author Marko Kunic <kunicmarko20@gmail.com>


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 1.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
-->
I am targeting this branch because there is no other branches.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

Closes #28 

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Changed
Processing for "children" option. Now annotations allowed old notation
children={"app.admin.product"}
and new notation (fieldName: associatedAdmin)
children={"product": "app.admin.product"}
but old notation now deprecated and will not work with Sonata 4.0.
```

<!--
     If this is a work in progress, uncomment this section.
     You can add as many tasks as you want.
     If some are not relevant, just remove them.
    
    ## To do
    
    - [ ] Update the tests
    - [ ] Update the documentation
    - [ ] Add an upgrade note
-->

## Subject
Allow to specify the field name for associated admins in children option.

<!-- Describe your Pull Request content here -->